### PR TITLE
Fixed an error in the action name

### DIFF
--- a/.github/workflows/scheduled-workflow.yml
+++ b/.github/workflows/scheduled-workflow.yml
@@ -26,7 +26,7 @@ jobs:
           git commit -m "Update data" -a
           
       - name: Push changes
-        uses: ad-m/github-push-action@develop
+        uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
I misunderstood one thing in the documentation that `ad-m/github-push-action@master` is a standard action name and should not be changed (I thought I could specify `ad-m/github-push-action@develop`). But I tested it on my test organization and the push goes to the `develop` branch if the workflow file is in the `develop`.
Screen from my test org:
![Screenshot 2020-12-21 at 13 29 36](https://user-images.githubusercontent.com/48979187/102772730-ac4cd480-4390-11eb-8237-fe120d13316b.png)
